### PR TITLE
feat: writable subgraph_request_id + context.remove in mocks (AS-389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+### 🚀 Features
+
+- Subgraph response mocks now expose a writable `subgraph_request_id`, enabling tests that exercise the request/response id correlation pattern. ([AS-389](https://apollographql.atlassian.net/browse/AS-389), requested via [TSH-22538](https://apollographql.atlassian.net/browse/TSH-22538))
+- `request.context` and `response.context` now support `remove(key)`, returning the removed value (or unit if the key was absent). Keeps parity with the existing `insert` / `upsert` / indexer-get surface.
+
+### 🛠 Maintenance
+
+- Bumped `apollo-router` git pin to include the two additions above. Router fork branch `feature/rhaitest-v2.12.0` remains the source; pin switched from `branch = ...` to `rev = ...` for reproducibility.
+
 ## 0.3.0 (2026-04-09)
 
 ### ❗️Breaking ❗

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ debug = true
 
 [dependencies]
 #apollo-router = { path = "/Users/andrew/source/repos/router/apollo-router" }
-apollo-router = { git = "https://github.com/apollosolutions/router.git", branch = "feature/rhaitest-v2.12.0" }
+apollo-router = { git = "https://github.com/apollosolutions/router.git", rev = "3e1132a996014abbe2c040185a130dc9cce0b948" }
 clap = { version = "4.5.1", features = ["derive"] }
 colored = "2.1.0"
 glob = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -379,6 +379,27 @@ test("Should not throw an error when clients header are provided", ||{
 });
 ```
 
+#### Writable `subgraph_request_id` on subgraph response mocks
+
+The mock subgraph response exposes `subgraph_request_id` as a read/write property. This lets tests exercise the correlation pattern where a script stashes state on `request.context` keyed by the subgraph request id and pulls it back on the response side.
+
+```rhai
+let response = apollo_mocks::get_subgraph_service_response();
+response.subgraph_request_id = "custom-id-xyz";
+```
+
+#### `context.remove(key)` on request and response contexts
+
+Both `request.context` and `response.context` support `remove(key)`, returning the removed value (or `()` if the key was absent). Keeps parity with the existing `insert` / `upsert` / indexer-get surface.
+
+```rhai
+let response = apollo_mocks::get_subgraph_service_response();
+response.context["correlation:trace"] = #{ trace_id: "abc" };
+let removed = response.context.remove("correlation:trace");
+```
+
+See [`examples/subgraph_request_id_correlation.test.rhai`](examples/subgraph_request_id_correlation.test.rhai) for the full correlation pattern end to end.
+
 ### Logging Methods
 
 This library injects in identifiers for each of the Router logging methods. This can be used to test that a particular log method was called after calling your functions.

--- a/examples/subgraph_request_id_correlation.rhai
+++ b/examples/subgraph_request_id_correlation.rhai
@@ -1,0 +1,23 @@
+// Demonstrates the subgraph_request_id correlation pattern Indeed and other
+// customers use in production: stash a payload on request.context keyed by
+// the subgraph request id, then pull and remove it on the response side.
+//
+// This file is the "script under test" for subgraph_request_id_correlation.test.rhai;
+// the test file imports this module and exercises these hooks against the mocks.
+// Use this pair as a copy-paste template for testing your own correlation logic.
+
+fn subgraph_request(request) {
+    let rid = request.subgraph_request_id;
+    request.context["correlation:" + rid] = #{
+        started_at: "2026-04-29T00:00:00Z",
+        attempt: 1,
+    };
+}
+
+fn subgraph_response(response) {
+    let rid = response.subgraph_request_id;
+    let payload = response.context.remove("correlation:" + rid);
+    if payload != () {
+        response.headers["x-correlation-started-at"] = payload.started_at;
+    }
+}

--- a/examples/subgraph_request_id_correlation.test.rhai
+++ b/examples/subgraph_request_id_correlation.test.rhai
@@ -1,0 +1,69 @@
+// Exercises the subgraph_request_id correlation pattern:
+//   - stash a payload on request.context keyed on subgraph_request_id
+//   - mirror the id onto the mock subgraph response
+//   - pull + remove the payload from response.context on the way out
+//
+// Covers: writable response.subgraph_request_id, context.remove() on both
+// request.context and response.context.
+
+test("Should allow writing to subgraph_request_id on subgraph response mock", ||{
+    let mock_resp = apollo_mocks::get_subgraph_service_response();
+    let original = mock_resp.subgraph_request_id;
+    mock_resp.subgraph_request_id = "custom-id-xyz";
+
+    expect(mock_resp.subgraph_request_id).to_be("custom-id-xyz");
+    expect(mock_resp.subgraph_request_id).not().to_be(original);
+});
+
+test("Should remove an entry from response context", ||{
+    let mock_resp = apollo_mocks::get_subgraph_service_response();
+    mock_resp.context["correlation:trace"] = #{ trace_id: "abc" };
+
+    let removed = mock_resp.context.remove("correlation:trace");
+
+    expect(removed.trace_id).to_be("abc");
+    expect(mock_resp.context["correlation:trace"]).to_be(());
+});
+
+test("Should remove an entry from request context", ||{
+    let supergraph_request = apollo_mocks::get_supergraph_service_request();
+    let mock_req = apollo_mocks::get_subgraph_service_request(supergraph_request);
+    mock_req.context["correlation:trace"] = #{ trace_id: "def" };
+
+    let removed = mock_req.context.remove("correlation:trace");
+
+    expect(removed.trace_id).to_be("def");
+    expect(mock_req.context["correlation:trace"]).to_be(());
+});
+
+test("Should return unit when removing a missing context key", ||{
+    let mock_resp = apollo_mocks::get_subgraph_service_response();
+    let removed = mock_resp.context.remove("never-set");
+
+    expect(removed).to_be(());
+});
+
+test("Should support the full subgraph_request_id correlation pattern", ||{
+    // 1. Incoming subgraph request: stash a correlation payload keyed on the
+    //    subgraph_request_id.
+    let supergraph_request = apollo_mocks::get_supergraph_service_request();
+    let mock_req = apollo_mocks::get_subgraph_service_request(supergraph_request);
+    let rid = mock_req.subgraph_request_id;
+    mock_req.context["correlation:" + rid] = #{ trace_id: "abc-123", span: "s1" };
+
+    // 2. Outgoing subgraph response: writes back with the same id, pulls the
+    //    payload, removes it. In a real script the payload would be on
+    //    request.context; for this mock example we copy it onto
+    //    response.context to simulate the merge the Router does between
+    //    request and response contexts for subgraph calls.
+    let mock_resp = apollo_mocks::get_subgraph_service_response();
+    mock_resp.subgraph_request_id = rid;
+    mock_resp.context["correlation:" + rid] = mock_req.context["correlation:" + rid];
+
+    let payload = mock_resp.context.remove("correlation:" + rid);
+
+    expect(mock_resp.subgraph_request_id).to_be(rid);
+    expect(payload.trace_id).to_be("abc-123");
+    expect(payload.span).to_be("s1");
+    expect(mock_resp.context["correlation:" + rid]).to_be(());
+});

--- a/examples/subgraph_request_id_correlation.test.rhai
+++ b/examples/subgraph_request_id_correlation.test.rhai
@@ -67,3 +67,36 @@ test("Should support the full subgraph_request_id correlation pattern", ||{
     expect(payload.span).to_be("s1");
     expect(mock_resp.context["correlation:" + rid]).to_be(());
 });
+
+// The following two tests demonstrate the idiomatic rhai-test pattern: import
+// a sibling .rhai source file (the script under test) and exercise its hooks
+// against the mocks. Use this shape as a copy-paste template for testing your
+// own correlation logic.
+
+test("Should stash correlation payload on request context via subgraph_request hook", ||{
+    let supergraph_request = apollo_mocks::get_supergraph_service_request();
+    let request = apollo_mocks::get_subgraph_service_request(supergraph_request);
+    let rid = request.subgraph_request_id;
+
+    import "subgraph_request_id_correlation" as correlation;
+    correlation::subgraph_request(request);
+
+    let stashed = request.context["correlation:" + rid];
+    expect(stashed.attempt).to_be(1);
+    expect(stashed.started_at).to_be("2026-04-29T00:00:00Z");
+});
+
+test("Should pull and remove correlation payload via subgraph_response hook", ||{
+    let response = apollo_mocks::get_subgraph_service_response();
+    response.subgraph_request_id = "test-rid-9";
+    response.context["correlation:test-rid-9"] = #{
+        started_at: "2026-04-29T00:00:00Z",
+        attempt: 1,
+    };
+
+    import "subgraph_request_id_correlation" as correlation;
+    correlation::subgraph_response(response);
+
+    expect(response.headers["x-correlation-started-at"]).to_be("2026-04-29T00:00:00Z");
+    expect(response.context["correlation:test-rid-9"]).to_be(());
+});


### PR DESCRIPTION
## Summary

- Pins `apollo-router` to the merged commit on `feature/rhaitest-v2.12.0` that adds `Context::remove` and a public setter for `subgraph::Response.subgraph_request_id` (`3e1132a996014abbe2c040185a130dc9cce0b948`).
- Adds `examples/subgraph_request_id_correlation.test.rhai` exercising both affordances end to end, including the Indeed-flagged correlation pattern.
- Documents the new surface in `README.md` and `CHANGELOG.md`.

No Rust source changes in this repo. The new Rhai bindings (`context.remove(...)` and `set = "subgraph_request_id"`) live in the Router fork and are picked up through `ApolloRhai::engine::registration::register(engine)` which `register_rhai_functions_and_types` already calls.

## Why

Closes [AS-389](https://apollographql.atlassian.net/browse/AS-389). Unblocks [TSH-22538](https://apollographql.atlassian.net/browse/TSH-22538) from Indeed.

The mock subgraph `Response` previously exposed a read-only `subgraph_request_id`, and `Context` had no public `remove`. This blocked unit testing of Rhai scripts using the common correlation pattern (stash state keyed on `subgraph_request_id` in `request.context`, pull + remove from `response.context`).

## Router fork PR

Depends on: [apollosolutions/router#1](https://github.com/apollosolutions/router/pull/1) (merged into `feature/rhaitest-v2.12.0`).

## Test plan

- [ ] `cargo build`
- [ ] `cargo test`
- [ ] `cargo run -- --directory examples` — all existing examples + new correlation example pass
- [ ] Spot-check `examples/subgraph_request_id_correlation.test.rhai`: all five `test(...)` blocks evaluate and none returns an error

## Related

- [AS-389](https://apollographql.atlassian.net/browse/AS-389)
- [TSH-22538](https://apollographql.atlassian.net/browse/TSH-22538)
- [AS-384](https://apollographql.atlassian.net/browse/AS-384) — previous rhai-test bump to Rhai 1.23.6 / Router 2.12.0
